### PR TITLE
add "sensor_pose_estimation based control" flag in launch file.

### DIFF
--- a/jsk_mbzirc_common/CMakeLists.txt
+++ b/jsk_mbzirc_common/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(catkin REQUIRED COMPONENTS gazebo_ros std_msgs geometry_msgs)
 
 # Depend on system install of Gazebo and SDFormat
 find_package(gazebo REQUIRED)
-
 find_package(Boost REQUIRED COMPONENTS thread random)
 
 ###################################
@@ -34,6 +33,8 @@ target_link_libraries(mbzirc_gazebo_treasure_plugin ${GAZEBO_LIBRARIES} ${catkin
 add_library(mbzirc_gazebo_gimbal_plugin src/mbzirc_gazebo_gimbal_plugin.cpp)
 target_link_libraries(mbzirc_gazebo_gimbal_plugin ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+add_library(mbzirc_gazebo_drone_additional_plugin src/mbzirc_gazebo_drone_additional_plugin.cpp)
+target_link_libraries(mbzirc_gazebo_drone_additional_plugin ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 #############
 ## Install ##

--- a/jsk_mbzirc_common/CMakeLists.txt
+++ b/jsk_mbzirc_common/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS gazebo_ros std_msgs geometry_msgs)
 
 # Depend on system install of Gazebo and SDFormat
 find_package(gazebo REQUIRED)
+
 find_package(Boost REQUIRED COMPONENTS thread random)
 
 ###################################
@@ -30,11 +31,15 @@ target_link_libraries(mbzirc_gazebo_panel_plugin ${GAZEBO_LIBRARIES} ${catkin_LI
 add_library(mbzirc_gazebo_treasure_plugin src/mbzirc_gazebo_treasure_plugin.cpp)
 target_link_libraries(mbzirc_gazebo_treasure_plugin ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
+add_library(mbzirc_gazebo_gimbal_plugin src/mbzirc_gazebo_gimbal_plugin.cpp)
+target_link_libraries(mbzirc_gazebo_gimbal_plugin ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+
 #############
 ## Install ##
 #############
 install(TARGETS
-  mbzirc_gazebo_truck_plugin mbzirc_gazebo_panel_plugin mbzirc_gazebo_treasure_plugin
+  mbzirc_gazebo_truck_plugin mbzirc_gazebo_panel_plugin mbzirc_gazebo_treasure_plugin mbzirc_gazebo_gimbal_plugin
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   )

--- a/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_drone_additional_plugin.h
+++ b/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_drone_additional_plugin.h
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef MBZIRC_GAZEBO_TRUCK_PLUGIN_H
-#define MBZIRC_GAZEBO_TRUCK_PLUGIN_H
+#ifndef MBZIRC_GAZEBO_DRONE_PLUGIN_H
+#define MBZIRC_GAZEBO_DRONE_PLUGIN_H
 
 #include <boost/bind.hpp>
 
@@ -43,20 +43,18 @@
 #include <ros/callback_queue.h>
 #include <ros/ros.h>
 #include <std_msgs/String.h>
+#include <std_srvs/Empty.h>
 #include <nav_msgs/Odometry.h>
+
 
 namespace gazebo
 {
 
-class GazeboTruck : public ModelPlugin
+class GazeboDrone : public ModelPlugin
 {
 public:
-  GazeboTruck();
-  virtual ~GazeboTruck();
-
-  // http://www.mbzirc.com/assets/files/MBZIRC-Challenge-Description-Document-V2-7SEP2015.pdf
-  static const float CIRCLE_RADIUS = 20.0;
-  static const float CIRCLE_DISTANCE = 55.0;
+  GazeboDrone();
+  virtual ~GazeboDrone();
 
 protected:
   virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
@@ -73,17 +71,23 @@ private:
   std::string namespace_;
 
   ros::NodeHandle* node_handle_;
-  ros::Publisher pub_score_, pub_time_; 
+  ros::Publisher  pub_gt_z_, pub_ee_z_; 
   ros::Subscriber sub_drone_state_;
+  ros::ServiceClient motor_client_;
+
   ros::Time state_stamp_;
 
   boost::mutex lock;
 
+  float landing_height_;
+  bool takeoff_flag_;
+bool terminated_flag_;
+
   event::ConnectionPtr update_connection_;
 
-  double traversed_;
-  common::Time last_time_;
-  bool terminated_;
+
+  void DroneStateCallback(const nav_msgs::OdometryConstPtr& state_msg);
+
 };
 
 }

--- a/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_gimbal_plugin.h
+++ b/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_gimbal_plugin.h
@@ -1,0 +1,113 @@
+#ifndef GAZEBO_GIMBAL_PLUGIN_H
+#define GAZEBO_GIMBAL_PLUGIN_H
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/Time.hh>
+#include <gazebo/math/Quaternion.hh>
+#include <gazebo/common/Events.hh>
+#include <gazebo/physics/physics.hh>
+
+
+// ROS 
+#include <ros/ros.h>
+#include <ros/callback_queue.h>
+#include <tf/transform_broadcaster.h>
+#include <tf/transform_listener.h>
+#include <geometry_msgs/QuaternionStamped.h>
+#include <sensor_msgs/JointState.h>
+#include <geometry_msgs/Twist.h>
+#include <sensor_msgs/Imu.h>
+#include <nav_msgs/Odometry.h>
+#include <std_srvs/Empty.h>
+
+// Boost
+#include <boost/thread.hpp>
+#include <boost/bind.hpp>
+
+#include <cmath>
+
+// #include <hector_gazebo_plugins/update_timer.h>
+
+namespace gazebo
+{
+
+class GazeboGimbal : public ModelPlugin
+{
+public:
+  GazeboGimbal();
+  virtual ~GazeboGimbal();
+
+protected:
+  virtual void Load(physics::ModelPtr _model, sdf::ElementPtr _sdf);
+  virtual void Update();
+  virtual void Reset();
+
+private:
+  ros::NodeHandle* node_handle_;
+
+  ros::Subscriber imu_subscriber_;
+  ros::Subscriber state_subscriber_;
+  ros::Publisher joint_state_pub_;
+  tf::TransformListener* transform_listener_;
+
+  ros::CallbackQueue callback_queue_;
+  common::Time prev_update_time_;
+  event::ConnectionPtr update_connection_;
+
+  physics::WorldPtr world_;
+  physics::LinkPtr link_;
+  std::string link_name_;
+
+  math::Quaternion rotation_;
+  geometry_msgs::QuaternionStamped::ConstPtr current_cmd_;
+  sensor_msgs::JointState joint_state_;
+
+  ros::Time state_stamp_;
+math::Pose pose_;
+  math::Vector3 euler_;
+
+  std::string namespace_;
+  std::string imu_topic_;
+  std::string state_topic_;
+
+  // parameters
+  std::string robot_name_space_;
+  std::string topic_name_;
+  std::string joint_state_name_;
+  common::Time control_period_;
+
+  float proportional_controller_gain_;
+  float derivative_controller_gain_;
+  float integral_controller_gain_;
+  double maximum_velocity_;
+  float maximum_torque_;
+double time_constant_;
+
+  unsigned int count_of_servos_;
+  unsigned int order_of_axes_[3];
+
+
+
+  void calculateVelocities(double dt);
+  void publish_joint_states();
+float updatePID(float& filter_command, float new_input, float x, float dx, float& i_term, float dt);
+
+  void imuCallback(const sensor_msgs::ImuConstPtr&);
+  void stateCallback(const nav_msgs::OdometryConstPtr&);
+
+  struct Servo {
+    std::string name;
+    math::Vector3 axis;
+    physics::JointPtr joint;
+    float filter_command;
+    float i_term;
+    float velocity;
+    float angle;
+    Servo() : velocity() {}
+  } servos_[3];
+
+};
+
+}
+
+#endif 

--- a/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_truck_plugin.h
+++ b/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_truck_plugin.h
@@ -43,6 +43,7 @@
 #include <ros/callback_queue.h>
 #include <ros/ros.h>
 #include <std_msgs/String.h>
+#include <nav_msgs/Odometry.h>
 
 namespace gazebo
 {
@@ -72,7 +73,8 @@ private:
   std::string namespace_;
 
   ros::NodeHandle* node_handle_;
-  ros::Publisher pub_score_, pub_time_;
+  ros::Publisher pub_score_, pub_time_, pub_gt_z_, pub_ee_z_; 
+  ros::Subscriber sub_drone_state_;
   ros::Time state_stamp_;
 
   boost::mutex lock;
@@ -86,6 +88,8 @@ private:
   bool takeoff_flag_;
   double landing_height_;
   std::string drone_name_;
+
+  void DroneStateCallback(const nav_msgs::OdometryConstPtr& state_msg);
 
 };
 

--- a/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_truck_plugin.h
+++ b/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_truck_plugin.h
@@ -83,6 +83,10 @@ private:
   common::Time last_time_;
   bool terminated_;
 
+  bool takeoff_flag_;
+  double landing_height_;
+  std::string drone_name_;
+
 };
 
 }

--- a/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_truck_plugin.h
+++ b/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_truck_plugin.h
@@ -43,7 +43,6 @@
 #include <ros/callback_queue.h>
 #include <ros/ros.h>
 #include <std_msgs/String.h>
-#include <nav_msgs/Odometry.h>
 
 namespace gazebo
 {
@@ -74,7 +73,6 @@ private:
 
   ros::NodeHandle* node_handle_;
   ros::Publisher pub_score_, pub_time_; 
-  ros::Subscriber sub_drone_state_;
   ros::Time state_stamp_;
 
   boost::mutex lock;
@@ -84,6 +82,7 @@ private:
   double traversed_;
   common::Time last_time_;
   bool terminated_;
+
 };
 
 }

--- a/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_truck_plugin.h
+++ b/jsk_mbzirc_common/include/jsk_mbzirc_common/mbzirc_gazebo_truck_plugin.h
@@ -72,7 +72,7 @@ private:
   std::string namespace_;
 
   ros::NodeHandle* node_handle_;
-  ros::Publisher pub_score_, pub_time_; 
+  ros::Publisher pub_score_, pub_time_;
   ros::Time state_stamp_;
 
   boost::mutex lock;

--- a/jsk_mbzirc_common/src/mbzirc_gazebo_drone_additional_plugin.cpp
+++ b/jsk_mbzirc_common/src/mbzirc_gazebo_drone_additional_plugin.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2016, JSK Robotics Laboratory, The University of Tokyo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <jsk_mbzirc_common/mbzirc_gazebo_drone_additional_plugin.h>
+
+namespace gazebo {
+
+GazeboDrone::GazeboDrone()
+{
+}
+
+GazeboDrone::~GazeboDrone()
+{
+  event::Events::DisconnectWorldUpdateBegin(update_connection_);
+
+  node_handle_->shutdown();
+  delete node_handle_;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboDrone::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  gzwarn << "The GazeboDrone plugin is DEPRECATED in ROS hydro." << std::endl;
+
+  model_ = _model;
+  world_ = _model->GetWorld();
+  link_ = _model->GetLink();
+  link_name_ = link_->GetName();
+  namespace_.clear();
+
+  landing_height_ = -0.1; //init dummy height
+  takeoff_flag_ = false;
+  terminated_flag_ = false;
+
+
+  // load parameters from sdf
+  if (_sdf->HasElement("robotNamespace")) namespace_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
+
+  if (_sdf->HasElement("bodyName") && _sdf->GetElement("bodyName")->GetValue()) {
+    link_name_ = _sdf->GetElement("bodyName")->Get<std::string>();
+    link_ = _model->GetLink(link_name_);
+  }
+
+  if (!link)
+  {
+    ROS_FATAL("gazebo_ros_baro plugin error: bodyName: %s does not exist\n", link_name_.c_str());
+    return;
+  }
+
+
+  // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized())
+  {
+    ROS_FATAL_STREAM("A ROS node for Gazebo has not been initialized, unable to load plugin. "
+                     << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+    return;
+  }
+
+  node_handle_ = new ros::NodeHandle(namespace_);
+  pub_ee_z_ = node_handle_->advertise<std_msgs::String>("drone_estimated_height", 1);
+  pub_gt_z_ = node_handle_->advertise<std_msgs::String>("drone_groundtruth_height", 1);
+  sub_drone_state_ = node_handle_->subscribe<nav_msgs::Odometry>("/state", 1, &GazeboDrone::DroneStateCallback, this, ros::TransportHints().tcpNoDelay()); 
+  motor_client_ = node_handle_->serviceClient<std_srvs::Empty>("/shutdown");
+  update_connection_ = event::Events::ConnectWorldUpdateBegin(
+                                                              boost::bind(&GazeboDrone::Update, this));
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the controller
+void GazeboDrone::Update()
+{
+  boost::mutex::scoped_lock scoped_lock(lock);
+
+  if(terminated_flag_) return;
+
+
+  if(!takeoff_flag_)
+    {//TODO: check contact with model "arena" is better
+      if(landing_height_ < 0) landing_height_  = model_->GetWorldPose().pos.z;
+      if(model_->GetWorldPose().pos.z > landing_height_ + 0.05) //0.05m is a margin
+        takeoff_flag_ = true;
+    }
+  else
+    {//TODO: check contact with model "arena" is better
+      std::stringstream ss;
+      std_msgs::String msg_time;
+      ss << model_->GetWorldPose().pos.z - landing_height_;
+      msg_time.data = "height(ground truth):" + ss.str();
+      pub_gt_z_.publish(msg_time);
+
+
+      if(model_->GetWorldPose().pos.z < landing_height_ + 0.05) 
+        {
+          ROS_WARN("Hit the ground");
+          std_srvs::Empty srv;
+
+          if (motor_client_.call(srv))
+            {
+              terminated_flag_ = true;
+            }
+          else
+            ROS_ERROR("Failed to call service motor_shutdown");
+        }
+    }
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Reset the controller
+void GazeboDrone::Reset()
+{
+  state_stamp_ = ros::Time();
+}
+
+/////////////////////////////////////////////////////////////////////////
+/// Callback func for drone state
+void GazeboDrone::DroneStateCallback(const nav_msgs::OdometryConstPtr& state_msg)
+{
+  std::stringstream ss;
+  std_msgs::String msg_time;
+  double z = (state_msg->pose.pose.position.z >= 0)? state_msg->pose.pose.position.z: 0;
+  ss << z;
+  msg_time.data = "height(estimation):" + ss.str();
+  pub_ee_z_.publish(msg_time);
+}
+
+
+// Register this plugin with the simulator
+GZ_REGISTER_MODEL_PLUGIN(GazeboDrone)
+
+} // namespace gazebo

--- a/jsk_mbzirc_common/src/mbzirc_gazebo_gimbal_plugin.cpp
+++ b/jsk_mbzirc_common/src/mbzirc_gazebo_gimbal_plugin.cpp
@@ -1,0 +1,328 @@
+#include <jsk_mbzirc_common/mbzirc_gazebo_gimbal_plugin.h>
+
+
+#if (GAZEBO_MAJOR_VERSION > 1) || (GAZEBO_MINOR_VERSION >= 2)
+  #define RADIAN Radian
+#else
+  #define RADIAN GetAsRadian
+#endif
+
+
+namespace gazebo {
+
+
+enum
+{
+  FIRST = 0, SECOND = 1, THIRD = 2
+};
+
+enum
+{
+  xyz, zyx
+};
+
+
+GazeboGimbal::GazeboGimbal()
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+GazeboGimbal::~GazeboGimbal()
+{
+  event::Events::DisconnectWorldUpdateBegin(update_connection_);
+  delete transform_listener_;
+  node_handle_->shutdown();
+  delete node_handle_;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboGimbal::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  world_ = _model->GetWorld();
+  link_ = _model->GetLink();
+  link_name_ = link_->GetName();
+
+  // default parameters
+  robot_name_space_.clear();
+  imu_topic_.clear();
+  state_topic_.clear();
+  //topic_name_ = "drive";
+  joint_state_name_ = "joint_states";
+  //control_period_ = 0;
+  proportional_controller_gain_ = 8.0;
+  derivative_controller_gain_ = 1.0;
+  integral_controller_gain_ = 0.1;
+  maximum_velocity_ = 0.0;
+  maximum_torque_ = 0.0;
+  count_of_servos_ = 0;
+  time_constant_ = 0;
+
+
+  // load parameters from sdf
+  if (_sdf->HasElement("robotNamespace")) robot_name_space_ = _sdf->GetElement("robotNamespace")->Get<std::string>();
+  if (_sdf->HasElement("imuTopic"))       imu_topic_ = _sdf->GetElement("imuTopic")->Get<std::string>();
+  if (_sdf->HasElement("stateTopic"))     state_topic_ = _sdf->GetElement("stateTopic")->Get<std::string>();
+
+  if (_sdf->HasElement("jointStateName")) joint_state_name_ = _sdf->Get<std::string>("jointStateName");
+  if (_sdf->HasElement("firstServoName")) servos_[FIRST].name = _sdf->Get<std::string>("firstServoName");
+  if (_sdf->HasElement("firstServoAxis")) servos_[FIRST].axis = _sdf->Get<math::Vector3>("firstServoAxis");
+  if (_sdf->HasElement("secondServoName")) servos_[SECOND].name = _sdf->Get<std::string>("secondServoName");
+  if (_sdf->HasElement("secondServoAxis")) servos_[SECOND].axis = _sdf->Get<math::Vector3>("secondServoAxis");
+  if (_sdf->HasElement("thirdServoName")) servos_[THIRD].name = _sdf->Get<std::string>("thirdServoName");
+  if (_sdf->HasElement("thirdServoAxis")) servos_[THIRD].axis = _sdf->Get<math::Vector3>("thirdServoAxis");
+  if (_sdf->HasElement("proportionalControllerGain")) proportional_controller_gain_ = _sdf->Get<double>("proportionalControllerGain");
+  if (_sdf->HasElement("derivativeControllerGain")) derivative_controller_gain_ = _sdf->Get<double>("derivativeControllerGain");
+  if (_sdf->HasElement("IntegralControllerGain")) integral_controller_gain_ = _sdf->Get<double>("IntegralControllerGain");
+  if (_sdf->HasElement("maxVelocity")) maximum_velocity_ = _sdf->Get<double>("maxVelocity");
+  if (_sdf->HasElement("torque")) maximum_torque_ = _sdf->Get<double>("torque");
+  if (_sdf->HasElement("timeConstant")) time_constant_ = _sdf->Get<double>("maxVelocitytimeConstant");
+
+  double control_rate = 0.0;
+  if (_sdf->HasElement("controlRate")) control_rate = _sdf->Get<double>("controlRate");
+  control_period_ = control_rate > 0.0 ? 1.0/control_rate : 0.0;
+
+  servos_[FIRST].joint  = _model->GetJoint(servos_[FIRST].name);
+  servos_[SECOND].joint = _model->GetJoint(servos_[SECOND].name);
+  servos_[THIRD].joint  = _model->GetJoint(servos_[THIRD].name);
+
+
+  if (!servos_[FIRST].joint)
+    gzthrow("The controller couldn't get first joint");
+
+  count_of_servos_ = 1;
+  if (servos_[SECOND].joint) {
+    count_of_servos_ = 2;
+    if (servos_[THIRD].joint) {
+      count_of_servos_ = 3;
+    }
+  }
+  else {
+    if (servos_[THIRD].joint) {
+      gzthrow("The controller couldn't get second joint, but third joint was loaded");
+    }
+  }
+
+  // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized())
+  {
+    int argc = 0;
+    char** argv = NULL;
+    ros::init(argc, argv, "gazebo", ros::init_options::NoSigintHandler | ros::init_options::AnonymousName);
+  }
+
+
+
+
+
+  node_handle_ = new ros::NodeHandle(robot_name_space_);
+
+
+  transform_listener_ = new tf::TransformListener();
+  transform_listener_->setExtrapolationLimit(ros::Duration(1.0));
+
+  if (!imu_topic_.empty())
+  {
+    ros::SubscribeOptions ops = ros::SubscribeOptions::create<sensor_msgs::Imu>(
+      imu_topic_, 1,
+      boost::bind(&GazeboGimbal::imuCallback, this, _1),
+      ros::VoidPtr(), &callback_queue_);
+    imu_subscriber_ = node_handle_->subscribe(ops);
+
+    ROS_INFO_NAMED("gimbal servo", "Using imu information on topic %s as source of orientation and angular velocity.", imu_topic_.c_str());
+  }
+
+  if (!state_topic_.empty())
+  {
+    ros::SubscribeOptions ops = ros::SubscribeOptions::create<nav_msgs::Odometry>(
+      state_topic_, 1,
+      boost::bind(&GazeboGimbal::stateCallback, this, _1),
+      ros::VoidPtr(), &callback_queue_);
+    state_subscriber_ = node_handle_->subscribe(ops);
+
+    ROS_INFO_NAMED("gimbal servo", "Using state information on topic %s as source of state information.", state_topic_.c_str());
+  }
+
+
+  if (!joint_state_name_.empty()) {
+    joint_state_pub_ = node_handle_->advertise<sensor_msgs::JointState>(joint_state_name_, 10);
+  }
+
+  joint_state_.header.frame_id = transform_listener_->resolve(_model->GetLink()->GetName());
+
+  Reset();
+
+
+  update_connection_ = event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboGimbal::Update, this));
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Callbacks
+void GazeboGimbal::imuCallback(const sensor_msgs::ImuConstPtr& imu)
+{
+  pose_.rot.Set(imu->orientation.w, imu->orientation.x, imu->orientation.y, imu->orientation.z);
+  euler_ = pose_.rot.GetAsEuler();
+}
+
+void GazeboGimbal::stateCallback(const nav_msgs::OdometryConstPtr& state)
+{
+  if (imu_topic_.empty()) {
+    pose_.rot.Set(state->pose.pose.orientation.w, state->pose.pose.orientation.x, state->pose.pose.orientation.y, state->pose.pose.orientation.z);
+    euler_ = pose_.rot.GetAsEuler();
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the controller
+void GazeboGimbal::Update()
+{
+  // handle callbacks
+  callback_queue_.callAvailable();
+
+  common::Time step_time_;
+  step_time_ = world_->GetSimTime() - prev_update_time_;
+
+  if (imu_topic_.empty()) {
+    pose_ = link_->GetWorldPose();
+    euler_ = pose_.rot.GetAsEuler();
+  }
+
+  if (control_period_ == 0.0 || step_time_ > control_period_) {
+    calculateVelocities(step_time_.Float());
+    publish_joint_states();
+    prev_update_time_ = world_->GetSimTime();
+  }
+
+#if 0 //velocty
+  servos_[FIRST].joint->SetVelocity(0, servos_[FIRST].velocity);
+  if (count_of_servos_ > 1) {
+    servos_[SECOND].joint->SetVelocity(0, servos_[SECOND].velocity);
+    if (count_of_servos_ > 2) {
+      servos_[THIRD].joint->SetVelocity(0, servos_[THIRD].velocity);
+    }
+  }
+#else //pos, cheat
+  servos_[FIRST].joint->SetAngle(0, servos_[FIRST].angle);
+  if (count_of_servos_ > 1) {
+    servos_[SECOND].joint->SetAngle(0, servos_[SECOND].angle);
+    if (count_of_servos_ > 2) {
+      servos_[THIRD].joint->SetAngle(0, servos_[THIRD].angle);
+    }
+  }
+#endif
+
+  servos_[FIRST].joint->SetMaxForce(0, maximum_torque_);
+  if (count_of_servos_ > 1) {
+    servos_[SECOND].joint->SetMaxForce(0, maximum_torque_);
+    if (count_of_servos_ > 2) {
+      servos_[THIRD].joint->SetMaxForce(0, maximum_torque_);
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Reset the controller
+void GazeboGimbal::Reset()
+{
+  servos_[FIRST].velocity = 0;
+  servos_[SECOND].velocity = 0;
+  servos_[THIRD].velocity = 0;
+
+  servos_[FIRST].i_term = 0;
+  servos_[SECOND].i_term = 0;
+  servos_[THIRD].i_term = 0;
+
+
+  servos_[FIRST].angle = 0;
+  servos_[SECOND].angle = 0;
+  servos_[THIRD].angle = 0;
+
+
+  servos_[FIRST].filter_command = 0;
+  servos_[SECOND].filter_command = 0;
+  servos_[THIRD].filter_command = 0;
+
+  prev_update_time_ = world_->GetSimTime();
+
+  pose_.Reset();
+  euler_.Set();
+  state_stamp_ = ros::Time();
+
+}
+
+  float GazeboGimbal::updatePID(float& filter_command,  float new_input, float x, float dx, float& i_term, float dt)
+{
+  
+  // filter command
+  //dinput = (new_input - input) / (dt + time_constant);
+  filter_command  = (dt * new_input + time_constant_ * filter_command) / (dt + time_constant_);
+
+  float p_term = filter_command - x;
+  //d = dinput - dx;
+  float d_term = - dx;
+  i_term += dt * p_term;
+
+  float output = proportional_controller_gain_ * p_term + derivative_controller_gain_ * d_term + integral_controller_gain_ * i_term;
+  return output;
+}
+
+
+void GazeboGimbal::calculateVelocities(double dt)
+{
+  //double des_angle[3];
+  double actual_angle[3] = {0.0, 0.0, 0.0};
+  double actual_vel[3] = {0.0, 0.0, 0.0};
+
+  servos_[0].angle = -euler_.x;
+  servos_[1].angle = -euler_.y;
+  servos_[2].angle = -euler_.z; //Right?
+
+  actual_angle[FIRST] = servos_[FIRST].joint->GetAngle(0).RADIAN();
+  actual_vel[FIRST] = servos_[FIRST].joint->GetVelocity(0);
+
+
+  servos_[FIRST].velocity = updatePID(servos_[0].filter_command, servos_[0].angle, actual_angle[FIRST], actual_vel[FIRST], servos_[FIRST].i_term, dt);
+  if (maximum_velocity_ > 0.0 && fabs(servos_[FIRST].velocity) > maximum_velocity_) servos_[FIRST].velocity = (servos_[FIRST].velocity > 0 ? maximum_velocity_ : -maximum_velocity_);
+
+  if (count_of_servos_ > 1) {
+    actual_angle[SECOND] = servos_[SECOND].joint->GetAngle(0).RADIAN();
+    actual_vel[SECOND] = servos_[SECOND].joint->GetVelocity(0);
+    servos_[SECOND].velocity = updatePID(servos_[1].filter_command, servos_[1].angle, actual_angle[SECOND], actual_vel[SECOND], servos_[SECOND].i_term, dt);
+    if (maximum_velocity_ > 0.0 && fabs(servos_[SECOND].velocity) > maximum_velocity_) servos_[SECOND].velocity = (servos_[SECOND].velocity > 0 ? maximum_velocity_ : -maximum_velocity_);
+
+    if (count_of_servos_ == 3) {
+      actual_angle[THIRD] = servos_[THIRD].joint->GetAngle(0).RADIAN();
+      actual_vel[THIRD] = servos_[THIRD].joint->GetVelocity(0);
+      servos_[THIRD].velocity = updatePID(servos_[2].filter_command, servos_[2].angle, actual_angle[THIRD], actual_vel[THIRD], servos_[THIRD].i_term, dt);
+      if (maximum_velocity_ > 0.0 && fabs(servos_[THIRD].velocity) > maximum_velocity_) servos_[THIRD].velocity = (servos_[THIRD].velocity > 0 ? maximum_velocity_ : -maximum_velocity_);
+    }
+  }
+}
+
+void GazeboGimbal::publish_joint_states()
+{
+  if (!joint_state_pub_) return;
+
+  joint_state_.header.stamp.sec = (world_->GetSimTime()).sec;
+  joint_state_.header.stamp.nsec = (world_->GetSimTime()).nsec;
+
+  joint_state_.name.resize(count_of_servos_);
+  joint_state_.position.resize(count_of_servos_);
+  joint_state_.velocity.resize(count_of_servos_);
+
+  for (unsigned int i = 0; i < count_of_servos_; i++) {
+    joint_state_.name[i] = servos_[i].joint->GetName();
+    joint_state_.position[i] = servos_[i].joint->GetAngle(0).RADIAN();
+    joint_state_.velocity[i] = servos_[i].joint->GetVelocity(0);
+  }
+
+  joint_state_pub_.publish(joint_state_);
+}
+
+// Register this plugin with the simulator
+GZ_REGISTER_MODEL_PLUGIN(GazeboGimbal)
+
+} // namespace gazebo

--- a/jsk_mbzirc_common/src/mbzirc_gazebo_gimbal_plugin.cpp
+++ b/jsk_mbzirc_common/src/mbzirc_gazebo_gimbal_plugin.cpp
@@ -55,7 +55,7 @@ void GazeboGimbal::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   derivative_controller_gain_ = 1.0;
   integral_controller_gain_ = 0.1;
   maximum_velocity_ = 0.0;
-  maximum_torque_ = 0.0;
+  maximum_torque_ = 5; //test
   count_of_servos_ = 0;
   time_constant_ = 0;
 
@@ -196,7 +196,7 @@ void GazeboGimbal::Update()
     prev_update_time_ = world_->GetSimTime();
   }
 
-#if 0 //velocty
+#if 1 //velocty
   servos_[FIRST].joint->SetVelocity(0, servos_[FIRST].velocity);
   if (count_of_servos_ > 1) {
     servos_[SECOND].joint->SetVelocity(0, servos_[SECOND].velocity);
@@ -204,16 +204,7 @@ void GazeboGimbal::Update()
       servos_[THIRD].joint->SetVelocity(0, servos_[THIRD].velocity);
     }
   }
-#else //pos, cheat
-  servos_[FIRST].joint->SetAngle(0, servos_[FIRST].angle);
-  if (count_of_servos_ > 1) {
-    servos_[SECOND].joint->SetAngle(0, servos_[SECOND].angle);
-    if (count_of_servos_ > 2) {
-      servos_[THIRD].joint->SetAngle(0, servos_[THIRD].angle);
-    }
-  }
 #endif
-
   servos_[FIRST].joint->SetMaxForce(0, maximum_torque_);
   if (count_of_servos_ > 1) {
     servos_[SECOND].joint->SetMaxForce(0, maximum_torque_);
@@ -300,6 +291,10 @@ void GazeboGimbal::calculateVelocities(double dt)
       if (maximum_velocity_ > 0.0 && fabs(servos_[THIRD].velocity) > maximum_velocity_) servos_[THIRD].velocity = (servos_[THIRD].velocity > 0 ? maximum_velocity_ : -maximum_velocity_);
     }
   }
+
+  ROS_INFO("command: 0: %f, 1:%f", servos_[0].filter_command, servos_[1].filter_command);
+  ROS_INFO("actual:  0: %f, 1:%f", actual_angle[FIRST], actual_angle[SECOND]);
+  ROS_INFO("vel:  0: %f, 1:%f", servos_[FIRST].velocity, servos_[SECOND].velocity);
 }
 
 void GazeboGimbal::publish_joint_states()

--- a/jsk_mbzirc_common/urdf/drone/additional.xacro
+++ b/jsk_mbzirc_common/urdf/drone/additional.xacro
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<robot name="drone_additional" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <gazebo>
+    <plugin name="mbzirc_gazebo_drone_additional_plugin" filename="libmbzirc_gazebo_drone_additional_plugin.so">
+    </plugin>
+  </gazebo>
+</robot>

--- a/jsk_mbzirc_common/urdf/gimbal/gimbal.xacro
+++ b/jsk_mbzirc_common/urdf/gimbal/gimbal.xacro
@@ -1,0 +1,185 @@
+<?xml version="1.0"?>
+<!-- Revolute-Revolute Manipulator -->
+<robot name="gimbal_module" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+<!-- gazebo problem
+    problem1: the mass should not be too light(0.01, 0.02g is wrong) 
+     problem2: the continuous joint should have the root parent(means, there is no tree in the parent)
+-->
+
+
+  <!-- Constants for robot dimensions -->
+  <xacro:property name="PI" value="3.1415926535897931"/>  
+  <xacro:property name="link_mass" value="0.2"/>  
+  <xacro:property name="motor_mass" value="0.2"/>
+
+<!--
+  <gazebo>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+      <robotNamespace>/gimbal_module</robotNamespace>
+      <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+    </plugin>
+  </gazebo>
+  -->
+
+  <!-- Import Rviz colors -->
+  <xacro:include filename="$(find jsk_mbzirc_common)/urdf/gimbal/materials.xacro" />
+
+  <xacro:macro name="motor" params="name parent *origin motor_height r ">
+    <joint name="${name}_motor_joint" type="fixed">
+      <xacro:insert_block name="origin" />
+      <parent link="${parent}"/>
+      <child link="${name}_motor"/>
+    </joint>
+
+    <link name="${name}_motor">
+      <inertial>
+        <mass value="${motor_mass}" />
+        <origin xyz="0 0 ${motor_height/2}" rpy="0 0 0" />
+        <inertia
+            ixx="${motor_mass  * (r*r / 4.0 + motor_height * motor_height/ 12.0)}" ixy="0.0" ixz="0.0"
+            iyy="${motor_mass  * (r*r / 4.0 + motor_height * motor_height/ 12.0)}" iyz="0.0"
+            izz="${motor_mass / 2.0 * (r*r)}"/>
+      </inertial>
+      <visual>
+        <origin xyz="0 0 ${motor_height/2}" rpy="0 0 0" />
+        <geometry>
+          <cylinder radius="${r}" length="${motor_height}"/>q
+        </geometry>
+        <material name="orange"/>
+      </visual>
+      <collision>
+        <origin xyz="0 0 ${motor_height/2}" rpy="0 0 0" />
+        <geometry>
+          <!-- <cylinder radius="${r/2}" length="${motor_height/2}"/> -->
+          <box size="0.001 0.001 0.001"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <gazebo reference="${name}_motor">
+      <mu1>0.2</mu1>
+      <mu2>0.2</mu2>
+      <material>Gazebo/Orange</material>
+    </gazebo>
+  </xacro:macro>
+
+  <xacro:macro name="single_link" params="name *origin d1 d2 l">
+    <link name="${name}_link">
+      <inertial>
+        <mass value="${link_mass}" />
+        <xacro:insert_block name="origin" />
+        <inertia
+	    ixx="${link_mass / 12.0 * (d1*d1 + l*l)}" ixy="0.0" ixz="0.0"
+	    iyy="${link_mass / 12.0 * (l*l + d2*d2)}" iyz="0.0"
+	    izz="${link_mass / 12.0 * (d1*d2 + d1*d2)}"/>
+      </inertial>
+      <visual>
+        <xacro:insert_block name="origin" />
+        <geometry>
+	  <box size="${d1} ${d2} ${l}"/>
+        </geometry>
+        <material name="black"/>
+      </visual>
+      <collision>
+        <xacro:insert_block name="origin" />
+        <geometry>
+          <!--	  <box size="${d1} ${d2} ${l}"/> -->
+          <box size="0.001 0.001 0.001"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <gazebo reference="${name}_link">
+      <mu1>0.2</mu1>
+      <mu2>0.2</mu2>
+      <material>Gazebo/Black</material>
+    </gazebo>
+  </xacro:macro>
+
+  <xacro:macro name="gimbal" params="name parent topside *origin width motor_height z y x imu_topic_name">
+    <joint name="${name}_root_joint" type="fixed">
+     <xacro:insert_block name="origin" /> 
+      <parent link="${parent}"/>
+      <child link="${name}_first_link"/>
+    </joint>
+
+    <xacro:single_link name="${name}_first"  l="${z}" d1="${width}" d2="${width}" >
+      <xacro:if value="${topside}">
+        <origin xyz="0 0 ${z/2}" rpy="0 0 0" />
+      </xacro:if>
+      <xacro:unless value="${topside}">
+        <origin xyz="0 0 ${-z/2}" rpy="0 0 0" />
+      </xacro:unless>
+    </xacro:single_link>
+
+
+    <xacro:motor name="${name}_first" parent="${name}_first_link"  motor_height="${motor_height}" r="${width}" >
+      <xacro:if value="${topside}">
+        <origin xyz="${width/2} 0.0 ${z - width/2}" rpy="0 ${M_PI/2}  0"/>
+      </xacro:if>
+      <xacro:unless value="${topside}">
+        <origin xyz="${width/2} 0.0 ${-z + width/2}" rpy="0 ${M_PI/2}  0"/>
+      </xacro:unless>
+    </xacro:motor>
+
+
+    <joint name="${name}_rotor_joint1" type="continuous">
+      <parent link="${name}_first_link"/>
+      <child link="${name}_second_link"/>
+      <xacro:if value="${topside}">
+        <origin xyz="${motor_height + width} 0 ${z - width/2}" rpy="${-M_PI/2} 0 0"/>
+      </xacro:if>
+      <xacro:unless value="${topside}">
+        <origin xyz="${motor_height + width} 0  ${-z + width/2}" rpy="${-M_PI/2} 0 0"/>
+      </xacro:unless>
+      <axis xyz="1 0 0"/>
+      <dynamics damping="0.01"/>
+    </joint>
+
+
+    <xacro:single_link name="${name}_second"  l="${y}" d1="${width}" d2="${width}" >
+        <origin xyz="0 0 ${-y/2}" rpy="0 0 0" />
+    </xacro:single_link>
+
+    <joint name="second_third_links_joint" type="fixed">
+      <origin xyz="${-width/2} 0 ${-y - width/2}" rpy="${M_PI/2} 0 ${-M_PI/2}"/>
+      <parent link="${name}_second_link"/>
+      <child link="${name}_third_link"/>
+    </joint>
+
+    <xacro:single_link name="${name}_third"  l="${x + width}" d1="${width}" d2="${width}" >
+        <origin xyz="0 0 ${-x/2 - width/2}" rpy="0 0 0" />
+    </xacro:single_link>
+
+
+    <xacro:motor name="${name}_second" parent="${name}_third_link" motor_height="${motor_height}" r="${width}" >
+      <origin xyz="0  ${width/2} ${-x - width}" rpy="${-M_PI/2} 0 0"/>
+    </xacro:motor>
+
+
+    <joint name="${name}_rotor_joint2" type="continuous">
+      <parent link="${name}_second_link"/>
+      <child link="${name}_stabilized_link"/>
+      <origin xyz="${x + width / 2} 0 0" rpy="${M_PI/2} 0 0 "/>
+      <axis xyz="0 1 0"/>
+      <dynamics damping="0.01"/>
+    </joint>
+
+    <xacro:single_link name="${name}_stabilized"  l="${2*y}" d1="${width * 2}" d2="${width/2}" >
+      <origin xyz="0 0 0" rpy=" ${M_PI/2} 0 0" />
+    </xacro:single_link>
+
+
+    <gazebo>
+      <plugin name="mbzirc_gazebo_gimbal_plugin" filename="libmbzirc_gazebo_gimbal_plugin.so">
+        <imuTopic>${imu_topic_name}</imuTopic>
+        <firstServoName>${name}_rotor_joint1</firstServoName>
+        <secondServoName>${name}_rotor_joint2</secondServoName>
+      </plugin>
+    </gazebo>
+
+  </xacro:macro>
+
+
+</robot>

--- a/jsk_mbzirc_common/urdf/gimbal/gimbal.xacro
+++ b/jsk_mbzirc_common/urdf/gimbal/gimbal.xacro
@@ -176,6 +176,10 @@
         <imuTopic>${imu_topic_name}</imuTopic>
         <firstServoName>${name}_rotor_joint1</firstServoName>
         <secondServoName>${name}_rotor_joint2</secondServoName>
+        <proportionalControllerGain>80.0</proportionalControllerGain>
+        <derivativeControllerGain>0.2</derivativeControllerGain>
+        <IntegralControllerGain>0.1</IntegralControllerGain>
+        <torque>10.0</torque>
       </plugin>
     </gazebo>
 

--- a/jsk_mbzirc_common/urdf/gimbal/gimbal.xacro
+++ b/jsk_mbzirc_common/urdf/gimbal/gimbal.xacro
@@ -176,7 +176,7 @@
         <imuTopic>${imu_topic_name}</imuTopic>
         <firstServoName>${name}_rotor_joint1</firstServoName>
         <secondServoName>${name}_rotor_joint2</secondServoName>
-        <proportionalControllerGain>80.0</proportionalControllerGain>
+        <proportionalControllerGain>200.0</proportionalControllerGain>
         <derivativeControllerGain>0.2</derivativeControllerGain>
         <IntegralControllerGain>0.1</IntegralControllerGain>
         <torque>10.0</torque>

--- a/jsk_mbzirc_common/urdf/gimbal/materials.xacro
+++ b/jsk_mbzirc_common/urdf/gimbal/materials.xacro
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<robot>
+
+  <material name="black">
+    <color rgba="0.0 0.0 0.0 1.0"/>
+  </material>
+
+  <material name="blue">
+    <color rgba="0.0 0.0 0.8 1.0"/>
+  </material>
+
+  <material name="green">
+    <color rgba="0.0 0.8 0.0 1.0"/>
+  </material>
+
+  <material name="grey">
+    <color rgba="0.2 0.2 0.2 1.0"/>
+  </material>
+
+  <material name="orange">
+    <color rgba="${255/255} ${108/255} ${10/255} 1.0"/>
+  </material>
+
+  <material name="brown">
+    <color rgba="${222/255} ${207/255} ${195/255} 1.0"/>
+  </material>
+
+  <material name="red">
+    <color rgba="0.8 0.0 0.0 1.0"/>
+  </material>
+
+  <material name="white">
+    <color rgba="1.0 1.0 1.0 1.0"/>
+  </material>
+
+</robot>

--- a/jsk_mbzirc_tasks/config/task1.rviz
+++ b/jsk_mbzirc_tasks/config/task1.rviz
@@ -105,7 +105,7 @@ Visualization Manager:
       Enabled: true
       Invert Rainbow: false
       Max Color: 255; 255; 255
-      Max Intensity: 0
+      Max Intensity: 1.10511e-19
       Min Color: 0; 0; 0
       Min Intensity: 0
       Name: LaserScan
@@ -166,11 +166,11 @@ Visualization Manager:
       Value: true
       font: DejaVu Sans Mono
       height: 40
-      left: 650
+      left: 0
       line width: 3
       text size: 20
-      top: 10
-      width: 450
+      top: 60
+      width: 500
     - Background Alpha: 0.8
       Background Color: 0; 0; 0
       Class: jsk_rviz_plugin/OverlayText
@@ -183,12 +183,12 @@ Visualization Manager:
       Topic: /drone_estimated_height_overlay
       Value: true
       font: DejaVu Sans Mono
-      height: 100
-      left: 650
+      height: 40
+      left: 0
       line width: 2
       text size: 20
-      top: 150
-      width: 550
+      top: 100
+      width: 500
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -248,5 +248,5 @@ Window Geometry:
   Views:
     collapsed: false
   Width: 1855
-  X: 55
-  Y: 14
+  X: 551
+  Y: 310

--- a/jsk_mbzirc_tasks/config/task1.rviz
+++ b/jsk_mbzirc_tasks/config/task1.rviz
@@ -7,6 +7,8 @@ Panels:
         - /Global Options1
         - /Status1
         - /OverlayText1
+        - /OverlayText2
+        - /OverlayText3
       Splitter Ratio: 0.5
     Tree Height: 428
   - Class: rviz/Selection
@@ -145,12 +147,48 @@ Visualization Manager:
       Topic: /remaining_time_overlay
       Value: true
       font: DejaVu Sans Mono
-      height: 100
-      left: 10
+      height: 50
+      left: 0
       line width: 2
-      text size: 64
+      text size: 32
       top: 10
-      width: 370
+      width: 500
+    - Background Alpha: 0.8
+      Background Color: 0; 0; 0
+      Class: jsk_rviz_plugin/OverlayText
+      Enabled: true
+      Foreground Alpha: 0.8
+      Foreground Color: 170; 0; 0
+      Name: OverlayText
+      Overtake Color Properties: true
+      Overtake Position Properties: true
+      Topic: /drone_groundtruth_height_overlay
+      Value: true
+      font: DejaVu Sans Mono
+      height: 40
+      left: 650
+      line width: 3
+      text size: 20
+      top: 10
+      width: 450
+    - Background Alpha: 0.8
+      Background Color: 0; 0; 0
+      Class: jsk_rviz_plugin/OverlayText
+      Enabled: true
+      Foreground Alpha: 0.8
+      Foreground Color: 0; 170; 0
+      Name: OverlayText
+      Overtake Color Properties: true
+      Overtake Position Properties: true
+      Topic: /drone_estimated_height_overlay
+      Value: true
+      font: DejaVu Sans Mono
+      height: 100
+      left: 650
+      line width: 2
+      text size: 20
+      top: 150
+      width: 550
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -210,5 +248,5 @@ Window Geometry:
   Views:
     collapsed: false
   Width: 1855
-  X: 65
-  Y: 24
+  X: 55
+  Y: 14

--- a/jsk_mbzirc_tasks/launch/jsk_mbzirc_task_1.launch
+++ b/jsk_mbzirc_tasks/launch/jsk_mbzirc_task_1.launch
@@ -42,6 +42,15 @@
         args="/remaining_time /remaining_time_overlay jsk_rviz_plugins/OverlayText
               'text: m.data' --wait-for-start" />
 
+  <node pkg="jsk_mbzirc_tasks" name="drone_estimated_height_text_to_overlay" type="relay_field_728"
+        args="/drone_estimated_height /drone_estimated_height_overlay jsk_rviz_plugins/OverlayText
+              'text: m.data' --wait-for-start" />
+
+  <node pkg="jsk_mbzirc_tasks" name="drone_groundtruth_height_text_to_overlay" type="relay_field_728"
+        args="/drone_groundtruth_height /drone_groundtruth_height_overlay jsk_rviz_plugins/OverlayText
+              'text: m.data' --wait-for-start" />
+
+
   <group unless="$(arg headless)" >
     <node pkg="rviz" type="rviz" name="rviz" args="-d $(find jsk_mbzirc_tasks)/config/task1.rviz"/>
 

--- a/jsk_mbzirc_tasks/launch/jsk_mbzirc_task_1.launch
+++ b/jsk_mbzirc_tasks/launch/jsk_mbzirc_task_1.launch
@@ -14,6 +14,8 @@
 
   <arg name="cheat" default="false" />
 
+  <arg name="use_ground_truth" default="true" />
+
   <arg unless="$(arg cheat)" name="x" value="65"/>
   <arg     if="$(arg cheat)" name="x" value="0"/>
   <arg unless="$(arg cheat)" name="y" value="-25"/>
@@ -30,6 +32,9 @@
     <arg name="x" value="$(arg x)"/>
     <arg name="y" value="$(arg y)"/>
     <arg name="z" value="$(arg z)"/>
+    <arg name="use_ground_truth_for_tf" value="$(arg use_ground_truth)" />
+    <arg name="use_ground_truth_for_control" value="$(arg use_ground_truth)" />
+
   </include>
 
   <!-- workaround until https://github.com/ros/ros_comm/pull/728 get released --> 

--- a/jsk_mbzirc_tasks/launch/jsk_mbzirc_task_1.launch
+++ b/jsk_mbzirc_tasks/launch/jsk_mbzirc_task_1.launch
@@ -4,6 +4,8 @@
   <arg name="gui" default="false" />
   <arg name="headless" default="false"/>
   <arg name="teleopUGV" default="false"/>
+  <arg name="use_ground_truth" default="true" />
+  <arg name="gimbal" default="false"/>
 
   <include file="$(find jsk_mbzirc_common)/launch/mbzirc_arena_1.launch" >
     <arg name="paused" default="$(arg paused)"/>
@@ -14,9 +16,8 @@
 
   <arg name="cheat" default="false" />
 
-  <arg name="model" default="$(find jsk_mbzirc_tasks)/urdf/quadrotor_with_hokyo30lx_and_downward_cam.urdf.xacro" />
-
-  <arg name="use_ground_truth" default="true" />
+  <arg unless="$(arg gimbal)" name="model" value="$(find jsk_mbzirc_tasks)/urdf/quadrotor_with_hokyo30lx_and_downward_cam.urdf.xacro" />
+  <arg if="$(arg gimbal)" name="model" value="$(find jsk_mbzirc_tasks)/urdf/quadrotor_with_gimbal_downward_cam.urdf.xacro" />
 
   <arg unless="$(arg cheat)" name="x" value="65"/>
   <arg     if="$(arg cheat)" name="x" value="0"/>

--- a/jsk_mbzirc_tasks/launch/jsk_mbzirc_task_1.launch
+++ b/jsk_mbzirc_tasks/launch/jsk_mbzirc_task_1.launch
@@ -14,6 +14,8 @@
 
   <arg name="cheat" default="false" />
 
+  <arg name="model" default="$(find jsk_mbzirc_tasks)/urdf/quadrotor_with_hokyo30lx_and_downward_cam.urdf.xacro" />
+
   <arg name="use_ground_truth" default="true" />
 
   <arg unless="$(arg cheat)" name="x" value="65"/>
@@ -28,7 +30,7 @@
 
   <!-- Spawn simulated quadrotor uav -->
   <include file="$(find hector_quadrotor_gazebo)/launch/spawn_quadrotor.launch" >
-    <arg name="model" value="$(find jsk_mbzirc_tasks)/urdf/quadrotor_with_hokyo30lx_and_downward_cam.urdf.xacro"/>
+    <arg name="model" value="$(arg model)"/>
     <arg name="x" value="$(arg x)"/>
     <arg name="y" value="$(arg y)"/>
     <arg name="z" value="$(arg z)"/>
@@ -36,6 +38,7 @@
     <arg name="use_ground_truth_for_control" value="$(arg use_ground_truth)" />
 
   </include>
+
 
   <!-- workaround until https://github.com/ros/ros_comm/pull/728 get released --> 
   <node pkg="jsk_mbzirc_tasks" name="remain_time_text_to_overlay" type="relay_field_728"

--- a/jsk_mbzirc_tasks/urdf/quadrotor_with_gimbal_downward_cam.urdf.xacro
+++ b/jsk_mbzirc_tasks/urdf/quadrotor_with_gimbal_downward_cam.urdf.xacro
@@ -13,6 +13,7 @@
 
 
     <xacro:include filename="$(find jsk_mbzirc_common)/urdf/gimbal/gimbal.xacro" />
+    <xacro:include filename="$(find jsk_mbzirc_common)/urdf/drone/additional.xacro" />
 
 
     <xacro:gimbal name="gimbal1" parent="base_link" topside="false" width="0.015" motor_height="0.015" x="0.04" y="0.03" z="0.06" imu_topic_name="/raw_imu">
@@ -29,7 +30,7 @@
 
     <xacro:include filename="$(find hector_sensors_description)/urdf/generic_camera.urdf.xacro" />
 
-    <xacro:generic_camera name="downward_cam" parent="gimbal1_stabilized_link" ros_topic="camera/image" cam_info_topic="camera/camera_info" update_rate="20" res_x="640" res_y="480" image_format="L8" hfov="100">
+    <xacro:generic_camera name="downward_cam" parent="gimbal1_stabilized_link" ros_topic="camera/image" cam_info_topic="camera/camera_info" update_rate="20" res_x="640" res_y="480" image_format="L8" hfov="160">
       <origin xyz="0.0 0.0 -0.03" rpy="0 ${M_PI/2} 0"/>
     </xacro:generic_camera>
 

--- a/jsk_mbzirc_tasks/urdf/quadrotor_with_gimbal_downward_cam.urdf.xacro
+++ b/jsk_mbzirc_tasks/urdf/quadrotor_with_gimbal_downward_cam.urdf.xacro
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+
+<robot
+  name="quadrotor"
+  xmlns:xacro="http://www.ros.org/wiki/xacro"
+>
+
+    <xacro:property name="M_PI" value="3.1415926535897931" />
+    <!-- Included URDF Files -->
+
+    <xacro:include filename="$(find hector_quadrotor_description)/urdf/quadrotor_base.urdf.xacro" />
+    <xacro:quadrotor_base_macro />
+
+
+    <xacro:include filename="$(find jsk_mbzirc_common)/urdf/gimbal/gimbal.xacro" />
+
+
+    <xacro:gimbal name="gimbal1" parent="base_link" topside="false" width="0.015" motor_height="0.015" x="0.04" y="0.03" z="0.06" imu_topic_name="/raw_imu">
+      <origin xyz="-0.05 0.0 -0.04" rpy="0 0 0"/>
+    </xacro:gimbal>
+
+    <xacro:include filename="$(find hector_sensors_description)/urdf/hokuyo_utm30lx.urdf.xacro" />
+<!--
+    <xacro:hokuyo_utm30lx name="laser0" parent="gimbal1_stabilized_link" ros_topic="scan" update_rate="40" ray_count="1081" min_angle="-135" max_angle="135">
+      <origin xyz="0.0 0.0 0.05" rpy="0 0 0"/>
+    </xacro:hokuyo_utm30lx>
+-->
+
+
+    <xacro:include filename="$(find hector_sensors_description)/urdf/generic_camera.urdf.xacro" />
+
+    <xacro:generic_camera name="downward_cam" parent="gimbal1_stabilized_link" ros_topic="camera/image" cam_info_topic="camera/camera_info" update_rate="20" res_x="640" res_y="480" image_format="L8" hfov="100">
+      <origin xyz="0.0 0.0 -0.03" rpy="0 ${M_PI/2} 0"/>
+    </xacro:generic_camera>
+
+      <xacro:include filename="$(find hector_quadrotor_gazebo)/urdf/quadrotor_plugins.gazebo.xacro" />
+
+
+</robot>

--- a/jsk_mbzirc_tasks/urdf/quadrotor_with_hokyo30lx_and_downward_cam.urdf.xacro
+++ b/jsk_mbzirc_tasks/urdf/quadrotor_with_hokyo30lx_and_downward_cam.urdf.xacro
@@ -5,6 +5,7 @@
     <!-- Included URDF Files -->
     <xacro:include filename="$(find hector_quadrotor_description)/urdf/quadrotor_base.urdf.xacro" />
     <xacro:include filename="$(find hector_quadrotor_gazebo)/urdf/quadrotor_plugins.gazebo.xacro" />
+    <xacro:include filename="$(find jsk_mbzirc_common)/urdf/drone/additional.xacro" />
 
     <!-- Instantiate quadrotor_base_macro once (has no parameters atm) -->
     <xacro:quadrotor_base_macro />
@@ -20,7 +21,7 @@
 
     <!-- Downward facing camera -->
     <xacro:include filename="$(find hector_sensors_description)/urdf/generic_camera.urdf.xacro" />
-    <xacro:generic_camera name="downward_cam" parent="base_link" ros_topic="camera/image" cam_info_topic="camera/camera_info" update_rate="20" res_x="640" res_y="480" image_format="L8" hfov="100">
+    <xacro:generic_camera name="downward_cam" parent="base_link" ros_topic="camera/image" cam_info_topic="camera/camera_info" update_rate="20" res_x="640" res_y="480" image_format="L8" hfov="160">
       <origin xyz="0.4 0.0 -0.0" rpy="0 ${M_PI/2} 0"/>
     </xacro:generic_camera>
 


### PR DESCRIPTION
Add the arg "use_ground_truth" in launch file. 
When the  arg "use ground truth" is true, no pose estimation(egomotion) is processed, and the control is based on the ground truth value. 

On the other hand, when the arg is false, the pose estimation begins to integrate sensors (c.f. imu, gps, baro(hieght)) to generate a combined 6-dof state(odmetry). The control is then based on the odometry from the pose estimation. 

The gps and baro sensor model plugin is provide by either hector_quadcopter_gazebo_plugin or hector_gazebo_plugin which already contain the noise(based on Gussian). This issue is related to #63 and #64