### PR TITLE
[jsk_mbzirc] fix for travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ before_install:
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
   # Install ROS
-  - sudo apt-get install -y python-catkin-pkg python-catkin-tools python-rosdep python-wstool ros-$ROS_DISTRO-catkin
+  - sudo apt-get install -y -q -qq python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin xvfb
+  - sudo -H pip install 'catkin_tools==0.3.0'
   - source /opt/ros/$ROS_DISTRO/setup.bash
   # Setup for rosdep
   - sudo rosdep init
@@ -28,7 +29,6 @@ before_install:
 # Create a catkin workspace with the package under test.
 install:
   - mkdir -p ~/catkin_ws/src
-
   # Add the package under test to the workspace.
   - cd ~/catkin_ws/src
   - ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace
@@ -42,20 +42,22 @@ before_script:
   - wstool merge $CI_SOURCE_PATH/mbzirc.rosinstall
   - wstool up
 
-  # package depdencies: install using rosdep.
-  - cd ~/catkin_ws
-  - rosdep install -y -q -r --from-paths src --ignore-src --rosdistro $ROS_DISTRO
-
 # Compile and test.
 script:
   - source /opt/ros/$ROS_DISTRO/setup.bash
+  # package depdencies: install using rosdep.
   - cd ~/catkin_ws
-  - catkin build -p1 -j1
-  - catkin run_tests -p1 -j1
-  - catkin_test_results --all build
+  - rosdep install -y -q -r -n --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+  # build packages
+  - catkin build -p1 -j1 --no-status --summarize
+  - source ~/catkin_ws/devel/setup.bash
+  # run tests
+  - xvfb-run -a --server-args="-screen 0 800x600x24" catkin build --catkin-make-args run_tests -- -p1 -j1 --limit-status-rate 0.017 --summarize $REPOSITORY_NAME --no-deps
+  - catkin_test_results --all --verbose build
   - catkin clean -b
+  # build to install space
   - catkin config --install
-  - catkin build -p1 -j1
+  - catkin build -p1 -j1 --no-status --summarize
 after_failure:
   - find ${HOME}/.ros/test_results -type f -exec echo "== {} ==" \; -exec cat {} \;
   - for file in ${HOME}/.ros/log/rostest-*; do echo "=== $file ==="; cat $file; done

--- a/jsk_mbzirc_common/CMakeLists.txt
+++ b/jsk_mbzirc_common/CMakeLists.txt
@@ -48,7 +48,8 @@ install(DIRECTORY launch gazebo_model
 ## Testing ##
 #############
 if(CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS rostest roslaunch)
+  find_package(rostest REQUIRED)
+  find_package(roslaunch REQUIRED)
   roslaunch_add_file_check(launch/mbzirc_arena.launch)
   roslaunch_add_file_check(launch/mbzirc_arena_1.launch)
   roslaunch_add_file_check(launch/mbzirc_arena_2.launch)

--- a/jsk_mbzirc_common/package.xml
+++ b/jsk_mbzirc_common/package.xml
@@ -20,6 +20,9 @@
   <run_depend>gazebo_plugins</run_depend>
   <run_depend>gazebo_ros</run_depend>
 
+  <test_depend>rostest</test_depend>
+  <test_depend>roslaunch</test_depend>
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <gazebo_ros gazebo_model_path="${prefix}/gazebo_model/models" />

--- a/jsk_mbzirc_tasks/CMakeLists.txt
+++ b/jsk_mbzirc_tasks/CMakeLists.txt
@@ -31,7 +31,8 @@ install(DIRECTORY launch urdf config
 ## Testing ##
 #############
 if(CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS rostest roslaunch)
+  find_package(rostest REQUIRED)
+  find_package(roslaunch REQUIRED)
   # https://github.com/ros/ros_comm/pull/730
   set(roslaunch_check_script ${PROJECT_SOURCE_DIR}/script/roslaunch-check)
   roslaunch_add_file_check(launch/jsk_mbzirc_task_1.launch)

--- a/jsk_mbzirc_tasks/package.xml
+++ b/jsk_mbzirc_tasks/package.xml
@@ -28,6 +28,8 @@
 
   <run_depend>rviz</run_depend>
 
+  <test_depend>rostest</test_depend>
+  <test_depend>roslaunch</test_depend>
   <!-- The export tag contains other, unspecified, tags -->
   <export>
   </export>

--- a/jsk_mbzirc_tasks/test/jsk_mbzirc_task_2.test
+++ b/jsk_mbzirc_tasks/test/jsk_mbzirc_task_2.test
@@ -13,6 +13,6 @@
   <param name="remaining_time_test/test_duration" value="5.0" />
   <test test-name="remaining_time_test" pkg="rostest" type="hztest"  name="remaining_time_test" retry="2" />
 
-  <test test-name="completed_test" pkg="jsk_mbzirc_tasks" type="check_mission.py"  name="completed_test" retry="2" time-limit="120" />
+  <test test-name="completed_test" pkg="jsk_mbzirc_tasks" type="check_mission.py"  name="completed_test" retry="2" time-limit="600" />
 
 </launch>


### PR DESCRIPTION
This PR includes some updates for passing build and test script on travis using catkin tools.

- enable `xvfb` for gazebo rendering
- pin version of `catkin_tools` to 0.3.0
- suppress logging of apt-get
- suppress logging of catkin
- specify meta package name for testing to avoid including packages not in this repo for testing
- `source setup.bash` after `catkin build` for testing
- increase time limit to pass test on travis machine
- add `rostest` / `roslaunch` to `test_depend`