### PR TITLE
[mbzirc.rosinstall] use ros-simulation/gazebo_ros_pkgs indigo-devel instead of furushchev's fork

### DIFF
--- a/mbzirc.rosinstall
+++ b/mbzirc.rosinstall
@@ -19,5 +19,5 @@
 # https://github.com/ros-simulation/gazebo_ros_pkgs/pull/460
 - git:
     local-name: gazebo_ros_pkgs
-    uri: https://github.com/furushchev/gazebo_ros_pkgs.git
-    version: fix-camera-util
+    uri: https://github.com/ros-simulation/gazebo_ros_pkgs.git
+    version: indigo-devel


### PR DESCRIPTION
This reverts `mbzirc.rosinstall` to use `ros-simulation/gazebo_ros_pkgs` `indigo-devel` branch from my fork repo.
My pull request is merged into original repo.
(see https://github.com/ros-simulation/gazebo_ros_pkgs/pull/460)

- [x] [mbzirc.rosinstall] use ros-simulation/gazebo_ros_pkgs indigo-devel instead of furushchev's fork