### PR TITLE
[netusb_camera_driver] add param always_publish

### DIFF
--- a/netusb_camera_driver/README.md
+++ b/netusb_camera_driver/README.md
@@ -38,6 +38,8 @@ $ sudo cp udev/99-netusbcam.rules /etc/udev/rules.d
 
 ``` bash
 $ roslaunch netusb_camera_driver camera.launch
+# if you want to publish image topic even when subscriber is none:
+$ roslaunch netusb_camera_driver camera.launch always_publish:=true
 ```
 
 3. Launch Driver, Viewer and Reconfigure

--- a/netusb_camera_driver/include/netusb_camera_driver/netusb_camera_nodelet.h
+++ b/netusb_camera_driver/include/netusb_camera_driver/netusb_camera_nodelet.h
@@ -52,6 +52,7 @@ namespace netusb_camera_driver
 
     boost::shared_ptr<boost::thread> pub_thread_;
     boost::mutex conn_mutex_, cfg_mutex_;
+    bool always_publish_;
     std::string frame_id_;
     int cam_index_;
     int image_width_, image_height_, image_step_;

--- a/netusb_camera_driver/launch/camera.launch
+++ b/netusb_camera_driver/launch/camera.launch
@@ -2,6 +2,7 @@
   <arg name="camera_index" default="0" />
   <arg name="launch_manager" default="true" />
   <arg name="launch_image_proc" default="true" />
+  <arg name="always_publish" default="false" />
   <arg name="namespace" default="camera" />
   <arg name="manager" default="$(arg namespace)_nodelet_manager" />
 
@@ -15,6 +16,7 @@
           args="load netusb_camera_driver/NETUSBCameraNodelet /$(arg manager)">
       <param name="frame_id" value="$(arg namespace)" />
       <param name="camera_index" value="$(arg camera_index)" />
+      <param name="always_publish" value="$(arg always_publish)" />
     </node>
 
     <include file="$(find image_proc)/launch/image_proc.launch"


### PR DESCRIPTION
When `~always_publish` param is set `true`, camera driver node publishes image topic even if no subscriber is present.
